### PR TITLE
Add musl linux back into the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Build macOS wheels
         if: runner.os == 'macOS'
         env:
-          CIBW_BUILD: cp3?-*
           CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686 *-manylinux_aarch64 *-manylinux_ppc64le *-manylinux_s390x"
           CIBW_BUILD_VERBOSITY: 1
         run: |
@@ -76,7 +75,6 @@ jobs:
       - name: Build Windows wheels
         if: runner.os == 'Windows'
         env:
-          CIBW_BUILD: cp3?-*
           CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686 *-manylinux_aarch64 *-manylinux_ppc64le *-manylinux_s390x"
           CIBW_BUILD_VERBOSITY: 1
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         if: runner.os == 'Linux'
         env:
           CIBW_BUILD: cp3?-*
-          CIBW_SKIP: "cp35-* *-win32 *-musllinux_* *-manylinux_i686 *-manylinux_aarch64 *-manylinux_ppc64le *-manylinux_s390x"
+          CIBW_SKIP: "cp35-* *-win32 *-musllinux_i686 *-musllinux_aarch64 *-musllinux_ppc64le *-musllinux_s390x *-manylinux_i686 *-manylinux_aarch64 *-manylinux_ppc64le *-manylinux_s390x"
           CIBW_BUILD_VERBOSITY: 1
         run: |
           python setup.py sdist
@@ -54,7 +54,6 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: i686
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_SKIP: "*-musllinux_*"
         run: |
           python3 -m cibuildwheel --output-dir wheelhouse
 
@@ -63,7 +62,6 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_SKIP: "*-musllinux_*"
         run: |
           python3 -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Build Linux wheels and sdist
         if: runner.os == 'Linux'
         env:
-          CIBW_BUILD: cp3?-*
           CIBW_SKIP: "cp35-* *-win32 *-musllinux_i686 *-musllinux_aarch64 *-musllinux_ppc64le *-musllinux_s390x *-manylinux_i686 *-manylinux_aarch64 *-manylinux_ppc64le *-manylinux_s390x"
           CIBW_BUILD_VERBOSITY: 1
         run: |

--- a/scripts/setup-arm64.sh
+++ b/scripts/setup-arm64.sh
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 if [ ! -f "/usr/bin/go" ]; then
     echo "Downloading arm64 Golang"
-    curl -vvv -L -O https://golang.org/dl/go1.15.5.linux-arm64.tar.gz
+    if [ -x /usr/bin/curl ]; then
+        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    else
+        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    fi
     tar -xf go1.15.5.linux-arm64.tar.gz
+    if [ -x /lib/libc.musl-* ]; then
+        apk add --no-cache libc6-compat
+    fi
 fi

--- a/scripts/setup-arm64.sh
+++ b/scripts/setup-arm64.sh
@@ -4,7 +4,7 @@ if [ ! -f "/usr/bin/go" ]; then
     if [ -x /usr/bin/curl ]; then
         curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     else
-        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     fi
     tar -xf go1.15.5.linux-arm64.tar.gz
     if [ -x /lib/libc.musl-* ]; then

--- a/scripts/setup-arm64.sh
+++ b/scripts/setup-arm64.sh
@@ -2,9 +2,9 @@
 if [ ! -f "/usr/bin/go" ]; then
     echo "Downloading arm64 Golang"
     if [ -x /usr/bin/curl ]; then
-        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        curl -L -O https://golang.org/dl/go1.15.5.linux-arm64.tar.gz
     else
-        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-arm64.tar.gz
     fi
     tar -xf go1.15.5.linux-arm64.tar.gz
     if [ -x /lib/libc.musl-* ]; then

--- a/scripts/setup-arm6vl.sh
+++ b/scripts/setup-arm6vl.sh
@@ -4,7 +4,7 @@ if [ ! -f "/usr/bin/go" ]; then
     if [ -x /usr/bin/curl ]; then
         curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     else
-        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     fi
     tar -xf go1.15.5.linux-armv6l.tar.gz
     if [ -x /lib/libc.musl-* ]; then

--- a/scripts/setup-arm6vl.sh
+++ b/scripts/setup-arm6vl.sh
@@ -2,9 +2,9 @@
 if [ ! -f "/usr/bin/go" ]; then
     echo "Downloading arm6vl Golang"
     if [ -x /usr/bin/curl ]; then
-        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        curl -L -O https://golang.org/dl/go1.15.5.linux-armv6l.tar.gz
     else
-        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-armv6l.tar.gz
     fi
     tar -xf go1.15.5.linux-armv6l.tar.gz
     if [ -x /lib/libc.musl-* ]; then

--- a/scripts/setup-arm6vl.sh
+++ b/scripts/setup-arm6vl.sh
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 if [ ! -f "/usr/bin/go" ]; then
     echo "Downloading arm6vl Golang"
-    curl -L -O https://golang.org/dl/go1.15.5.linux-armv6l.tar.gz
+    if [ -x /usr/bin/curl ]; then
+        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    else
+        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    fi
     tar -xf go1.15.5.linux-armv6l.tar.gz
+    if [ -x /lib/libc.musl-* ]; then
+        apk add --no-cache libc6-compat
+    fi
 fi

--- a/scripts/setup-linux-32.sh
+++ b/scripts/setup-linux-32.sh
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 if [ ! -f "/usr/bin/go" ]; then
     echo "Downloading linux-386 Golang"
-    curl -L -O https://golang.org/dl/go1.15.5.linux-386.tar.gz
+    if [ -x /usr/bin/curl ]; then
+        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    else
+        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    fi
     tar -xf go1.15.5.linux-386.tar.gz
+    if [ -x /lib/libc.musl-* ]; then
+        apk add --no-cache libc6-compat
+    fi
 fi

--- a/scripts/setup-linux-32.sh
+++ b/scripts/setup-linux-32.sh
@@ -4,7 +4,7 @@ if [ ! -f "/usr/bin/go" ]; then
     if [ -x /usr/bin/curl ]; then
         curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     else
-        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     fi
     tar -xf go1.15.5.linux-386.tar.gz
     if [ -x /lib/libc.musl-* ]; then

--- a/scripts/setup-linux-32.sh
+++ b/scripts/setup-linux-32.sh
@@ -2,9 +2,9 @@
 if [ ! -f "/usr/bin/go" ]; then
     echo "Downloading linux-386 Golang"
     if [ -x /usr/bin/curl ]; then
-        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        curl -L -O https://golang.org/dl/go1.15.5.linux-386.tar.gz
     else
-        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-386.tar.gz
     fi
     tar -xf go1.15.5.linux-386.tar.gz
     if [ -x /lib/libc.musl-* ]; then

--- a/scripts/setup-linux-64.sh
+++ b/scripts/setup-linux-64.sh
@@ -4,7 +4,7 @@ if [ ! -f "/usr/bin/go" ]; then
     if [ -x /usr/bin/curl ]; then
         curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     else
-        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     fi
     tar -xf go1.15.5.linux-amd64.tar.gz
     if [ -x /lib/libc.musl-* ]; then

--- a/scripts/setup-linux-64.sh
+++ b/scripts/setup-linux-64.sh
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 if [ ! -f "/usr/bin/go" ]; then
     echo "Downloading linux-amd64 Golang"
-    curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    if [ -x /usr/bin/curl ]; then
+        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    else
+        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    fi
     tar -xf go1.15.5.linux-amd64.tar.gz
+    if [ -x /lib/libc.musl-* ]; then
+        apk add --no-cache libc6-compat
+    fi
 fi

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -2,9 +2,9 @@
 if [ ! -f "/usr/local/bin/go" ]; then
     echo "Downloading darwin-amd64 Golang"
     if [ -x /usr/bin/curl ]; then
-        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        curl -L -O https://golang.org/dl/go1.15.5.darwin-amd64.tar.gz
     else
-        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.darwin-amd64.tar.gz
     fi
     tar -xf go1.15.5.darwin-amd64.tar.gz
 fi

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -4,7 +4,7 @@ if [ ! -f "/usr/local/bin/go" ]; then
     if [ -x /usr/bin/curl ]; then
         curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     else
-        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+        wget -v https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
     fi
     tar -xf go1.15.5.darwin-amd64.tar.gz
 fi

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -1,6 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 if [ ! -f "/usr/local/bin/go" ]; then
     echo "Downloading darwin-amd64 Golang"
-    curl -L -O https://golang.org/dl/go1.15.5.darwin-amd64.tar.gz
+    if [ -x /usr/bin/curl ]; then
+        curl -L -O https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    else
+        wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+    fi
     tar -xf go1.15.5.darwin-amd64.tar.gz
 fi


### PR DESCRIPTION
* Add musllinux to the build matrix and try to get go running properly under alpine (Closes #31)
* Fix building wheels for Python 3.10 (Closes #29)