### PR TITLE
Update Makefile for Go >1.18 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 so:
-	go get -d
+	go install
 ifndef GOARCH
 	go build -buildmode=c-shared -o bluemonday.so .
 else


### PR DESCRIPTION
Go has deprecated the `go get` command and now requires the `go install` to replace. I have tested building this on a FreeBSD 14.1 Release amd64 device, and it installed just fine.