### PR TITLE
Modernize dependencies: update cffi to 2.0.0 and setuptools-golang to 2.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ pybluemonday/*.so
 .DS_Store
 bluemonday.o
 bluemonday.so
+bluemonday.c
+bluemonday.h
+bluemonday.cpython-*.so
 .eggs

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ subprocess.call(["make", "clean"], env=env)
 subprocess.call(["make", "so"], env=env)
 
 # Build the CFFI headers
-subprocess.call(["pip", "install", "cffi~=1.1"], env=env)
+subprocess.call(["pip", "install", "cffi>=2.0.0"], env=env)
 subprocess.call(["make", "ffi"], env=env)
 
 with open("pybluemonday/__init__.py", "r", encoding="utf8") as f:
@@ -65,6 +65,6 @@ setuptools.setup(
     # I'm not sure what this value is supposed to be
     build_golang={"root": "github.com/ColdHeat/pybluemonday"},
     ext_modules=[setuptools.Extension("pybluemonday/bluemonday", ["bluemonday.go"])],
-    setup_requires=["setuptools-golang==2.7.0", "cffi~=1.1"],
-    install_requires=["cffi~=1.1"],
+    setup_requires=["setuptools-golang==2.9.0", "cffi>=2.0.0"],
+    install_requires=["cffi>=2.0.0"],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 import platform
 import setuptools
 import subprocess
+import sys
 import re
 
 # Print out our uname for debugging purposes
@@ -37,7 +38,7 @@ subprocess.call(["make", "clean"], env=env)
 subprocess.call(["make", "so"], env=env)
 
 # Build the CFFI headers
-subprocess.call(["pip", "install", "cffi>=2.0.0"], env=env)
+subprocess.check_call([sys.executable, "-m", "pip", "install", "cffi>=2.0.0,<3"], env=env)
 subprocess.call(["make", "ffi"], env=env)
 
 with open("pybluemonday/__init__.py", "r", encoding="utf8") as f:
@@ -65,6 +66,6 @@ setuptools.setup(
     # I'm not sure what this value is supposed to be
     build_golang={"root": "github.com/ColdHeat/pybluemonday"},
     ext_modules=[setuptools.Extension("pybluemonday/bluemonday", ["bluemonday.go"])],
-    setup_requires=["setuptools-golang==2.9.0", "cffi>=2.0.0"],
-    install_requires=["cffi>=2.0.0"],
+    setup_requires=["setuptools-golang==2.9.0", "cffi>=2.0.0,<3"],
+    install_requires=["cffi>=2.0.0,<3"],
 )


### PR DESCRIPTION
## Summary
- Update cffi from `~=1.1` to `>=2.0.0`
- Update setuptools-golang from `2.7.0` to `2.9.0`

## Why the need to upgrade?
When pybluemonday is used alongside the `cryptography` package, it constrains users to `cryptography<=44.0.3` because pybluemonday requires `cffi~=1.1` (which means `<2.0`), while newer versions of cryptography require `cffi>=2.0.0`.

There is a **high severity vulnerability (CVSS 8.2)** affecting [cryptography](https://security.snyk.io/package/pip/cryptography) versions `<46.0.5`. Without resolving the hard conflict with `pybluemonday^0.0.14` which constrains `cffi~=1.1`, users cannot upgrade to the patched cryptography version.

This PR bumps the dependencies to their latest versions to unblock users from resolving this security issue.

## Test plan
- [x] Built Go shared library successfully
- [x] Built CFFI bindings with cffi 2.0.0
- [x] All 14 tests pass
- [x] Verified compatibility with cryptography 46.0.5 (which also requires cffi>=2.0.0)
- [x] Benchmarks run successfully

Tested with Python 3.14 and Go 1.25.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)